### PR TITLE
feat(chaper-9): Add newsletter publication endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,7 +416,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
 dependencies = [
  "axum-core",
- "axum-macros",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -462,17 +461,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "axum-macros"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ panic = 'abort'
 codegen-units = 1
 
 [dependencies]
-axum = { version = "0.8.4", features = ["tracing", "macros"] }
+axum = { version = "0.8.4", features = ["tracing"] }
 config = "0.15.15"
 dotenvy = "0.15.7"
 reqwest = { version = "0.12.23", default-features = false, features = [

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,7 +5,7 @@ pub type Result<T = ()> = std::result::Result<T, Error>;
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error(transparent)]
-    SurrealDb(#[from] Box<surrealdb::Error>),
+    SurrealDb(Box<surrealdb::Error>),
     #[error("{0:?}")]
     Migrations(String),
     #[error(transparent)]
@@ -23,6 +23,12 @@ pub enum Error {
 
     #[error("{0:?}")]
     Custom(String),
+}
+
+impl From<surrealdb::Error> for Error {
+    fn from(value: surrealdb::Error) -> Self {
+        Self::SurrealDb(Box::new(value))
+    }
 }
 
 impl IntoResponse for Error {

--- a/src/handlers/health_check.rs
+++ b/src/handlers/health_check.rs
@@ -1,13 +1,12 @@
+use crate::Result;
 use crate::model::ModelManager;
-use crate::{AppState, Result};
 use axum::extract::State;
 use reqwest::StatusCode;
 use std::sync::Arc;
 
-#[axum::debug_handler(state = AppState)]
 #[tracing::instrument(skip(mm))]
 pub async fn health(State(mm): State<Arc<ModelManager>>) -> Result<StatusCode> {
-    mm.db().await?.health().await.map_err(Box::new)?;
+    mm.db().await?.health().await?;
 
     Ok(StatusCode::OK)
 }

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,5 +1,7 @@
 mod health_check;
+mod newsletter;
 mod subscription;
 
 pub use health_check::*;
+pub use newsletter::*;
 pub use subscription::*;

--- a/src/handlers/newsletter.rs
+++ b/src/handlers/newsletter.rs
@@ -1,0 +1,40 @@
+use std::sync::Arc;
+
+use crate::{Result, email_client::EmailClient, model::ModelManager};
+use axum::{Json, extract::State, response::IntoResponse};
+use reqwest::StatusCode;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub struct BodyData {
+    title: String,
+    content: Content,
+}
+
+#[derive(Debug, Deserialize)]
+struct Content {
+    html: String,
+    text: String,
+}
+
+#[tracing::instrument(skip(mm, email_client))]
+pub async fn publish_newsletter(
+    State(mm): State<Arc<ModelManager>>,
+    State(email_client): State<Arc<EmailClient>>,
+    Json(body): Json<BodyData>,
+) -> Result<impl IntoResponse> {
+    let subscribers = mm.get_confirmed_subscribers().await?;
+
+    for subscriber in subscribers {
+        email_client
+            .send_email(
+                &subscriber.email.try_into()?,
+                &body.title,
+                &body.content.html,
+                &body.content.text,
+            )
+            .await?;
+    }
+
+    Ok(StatusCode::OK)
+}

--- a/src/handlers/subscription.rs
+++ b/src/handlers/subscription.rs
@@ -1,6 +1,4 @@
-use crate::{
-    AppState, Config, Result, domain::Subscriber, email_client::EmailClient, model::ModelManager,
-};
+use crate::{Config, Result, domain::Subscriber, email_client::EmailClient, model::ModelManager};
 use axum::extract::Query;
 use axum::{Form, extract::State};
 use rand::Rng;
@@ -16,7 +14,6 @@ pub struct FormData {
     pub name: String,
 }
 
-#[axum::debug_handler(state = AppState)]
 #[tracing::instrument(skip(mm, config, email_client))]
 pub async fn subscribe(
     State(mm): State<Arc<ModelManager>>,
@@ -40,7 +37,6 @@ pub struct Params {
     token: String,
 }
 
-#[axum::debug_handler(state = AppState)]
 #[tracing::instrument(skip(mm))]
 pub async fn confirm(
     State(mm): State<Arc<ModelManager>>,

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -1,7 +1,7 @@
 use crate::{
     Result,
     config::Config,
-    handlers::{confirm, health, subscribe},
+    handlers::{confirm, health, publish_newsletter, subscribe},
     state::AppState,
 };
 use axum::{
@@ -36,6 +36,7 @@ pub async fn init(config: Config) -> Result<(Router, AppState)> {
         .route("/health", get(health))
         .route("/subscriptions", post(subscribe))
         .route("/subscriptions/confirm", get(confirm))
+        .route("/newsletter", post(publish_newsletter))
         .layer(middleware)
         .with_state(state.clone());
 

--- a/tests/api/main.rs
+++ b/tests/api/main.rs
@@ -1,4 +1,5 @@
 mod health_check;
 mod helpers;
+mod newsletter;
 mod subscriptions;
 mod subscriptions_confirm;

--- a/tests/api/newsletter.rs
+++ b/tests/api/newsletter.rs
@@ -1,0 +1,132 @@
+use reqwest::{Method, StatusCode};
+use serde_json::json;
+use wiremock::{
+    Mock, ResponseTemplate,
+    matchers::{any, method},
+};
+
+use crate::helpers::{ConfirmationLinks, TestApp};
+
+async fn create_unconfirmed_subscriber(app: &TestApp) -> ConfirmationLinks {
+    let body = [("name", "let guin"), ("email", "ursula_le_guin@gmail.com")];
+
+    let _mock_guard = Mock::given(any())
+        .respond_with(ResponseTemplate::new(StatusCode::OK))
+        .named("Create unconfirmed subscriber")
+        .expect(1)
+        .mount_as_scoped(&app.email_server)
+        .await;
+
+    app.server.post("/subscriptions").form(&body).await;
+
+    let email_request = app
+        .email_server
+        .received_requests()
+        .await
+        .unwrap()
+        .pop()
+        .unwrap();
+    app.get_conformation_links(&email_request)
+}
+
+async fn create_confirmed_subscriber(app: &TestApp) {
+    let confirmation_links = create_unconfirmed_subscriber(app).await;
+
+    app.server
+        .get(&format!(
+            "{}?{}",
+            confirmation_links.html.path(),
+            confirmation_links.html.query().unwrap()
+        ))
+        .await
+        .assert_status_success();
+}
+
+#[tokio::test]
+async fn newsletter_are_not_delivered_to_unconfirmed_subscribers() {
+    // Arrange
+    let app = TestApp::new()
+        .await
+        .expect("Expected the app to be inisilized!");
+    create_unconfirmed_subscriber(&app).await;
+
+    // Act
+    let newsletter = serde_json::json!({
+       "title": "Newsletter title",
+       "content": {
+           "text": "Newsletter body as plain text",
+           "html": "<p>Newsletter body as html</p>",
+       },
+    });
+    let response = app.server.post("/newsletter").json(&newsletter).await;
+
+    // Assert
+    assert_eq!(response.status_code(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn newsletter_are_delivered_to_confirmed_subscribers() {
+    // Arrange
+    let app = TestApp::new()
+        .await
+        .expect("Expected the app to be inisilized!");
+    create_confirmed_subscriber(&app).await;
+
+    Mock::given(any())
+        .and(method(Method::POST))
+        .respond_with(ResponseTemplate::new(StatusCode::OK))
+        .expect(1)
+        .mount(&app.email_server)
+        .await;
+
+    // Act
+    let newsletter = serde_json::json!({
+       "title": "Newsletter title",
+       "content": {
+           "text": "Newsletter body as plain text",
+           "html": "<p>Newsletter body as html</p>",
+       },
+    });
+    let response = app.server.post("/newsletter").json(&newsletter).await;
+
+    // Assert
+    assert_eq!(response.status_code(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn newsletter_return_400_for_invalid_data() {
+    // Arrange
+    let app = TestApp::new()
+        .await
+        .expect("Expected the app to be inisilized!");
+    let test_cases = [
+        (
+            json!({
+               "content": {
+                   "text": "Newsletter body as plain text",
+                   "html": "<p>Newsletter body as html</p>",
+               },
+            }),
+            "messing title",
+        ),
+        (
+            json!({
+               "title": "Newsletter title",
+            }),
+            "messing content",
+        ),
+    ];
+
+    for (invalid_body, error_message) in test_cases {
+        // Act
+        let response = app.server.post("/newsletter").json(&invalid_body).await;
+
+        // Assert
+        assert_eq!(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            response.status_code(),
+            "The API did not fail with 400 Bad Request when the payload was {}.",
+            error_message
+        );
+    }
+}


### PR DESCRIPTION
* This commit introduces a new endpoint `/newsletter` that allows for publishing newsletters. 
* It includes the necessary handlers and data structures for handling newsletter publication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a POST /newsletter endpoint to publish newsletters to confirmed subscribers.

- Refactor
  - Simplified health endpoint to always return 200 OK.
  - Streamlined error handling and handler setup for more consistent behavior.

- Tests
  - Added end-to-end tests covering newsletter delivery to confirmed subscribers, ensuring unconfirmed subscribers are skipped, and validating request payloads.

- Chores
  - Updated dependency features to reduce unused options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->